### PR TITLE
Split tests to verify that the wrong alerts are not sent, and fix bug in maintenance window alerts

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/scannotifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scannotifications/messages/EventMessages.scala
@@ -74,6 +74,12 @@ object EventMessages {
   implicit val maintenanceEventMessages: Messages[SSMMaintenanceEvent] = new Messages[SSMMaintenanceEvent] {
     override def email(scanDetail: SSMMaintenanceEvent): Option[Email] = Option.empty
 
-    override def slack(scanDetail: SSMMaintenanceEvent): Option[String] = SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", "The Jenkins backup has failed. Please check the maintenance window in systems manager")))).asJson.noSpaces.some
+    override def slack(scanDetail: SSMMaintenanceEvent): Option[String] = {
+      if (scanDetail.success) {
+        None
+      } else {
+        SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", "The Jenkins backup has failed. Please check the maintenance window in systems manager")))).asJson.noSpaces.some
+      }
+    }
   }
 }


### PR DESCRIPTION
Some of the test cases include examples where emails and Slack alerts should _not_ be sent, e.g. because the ECR scan does not contain any vulnerabilities.

Before splitting the tests, these test cases were checking the wrong thing because they were only checking whether an email with an empty body was not being sent, rather than any email at all.

I tested this change by deliberately introducing a bug into the Slack and email message code so that they sent an alert even if there were no vulnerabilities. This should cause some of the tests to fail, but they stayed green. If you do the same thing on this branch, the relevant tests do fail.

Fixing these tests caught a bug in the maintenance window alerts. It was trying to send an alert even if the backup succeeded. I've fixed this issue in the code, but it's a bit of a moot point at the moment because the backup alerts aren't working at the moment anyway. Here's the card about fixing them: https://national-archives.atlassian.net/browse/TDR-652