### PR TITLE
Add link from email and Slack alerts to dev manual

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/scannotifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scannotifications/messages/EventMessages.scala
@@ -38,7 +38,9 @@ object EventMessages {
         val highBlock = countBlock(severityCounts.high, "high")
         val mediumBlock = countBlock(severityCounts.medium, "medium")
         val lowBlock = countBlock(severityCounts.low, "low")
-        SlackMessage(List(headerBlock, criticalBlock, highBlock, mediumBlock, lowBlock))
+        val documentationBlock = slackBlock("See the TDR developer manual for guidance on fixing these vulnerabilities: " +
+          "https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/alerts/ecr-scans.md")
+        SlackMessage(List(headerBlock, criticalBlock, highBlock, mediumBlock, lowBlock, documentationBlock))
           .asJson.noSpaces.some
       } else {
         Option.empty
@@ -61,6 +63,10 @@ object EventMessages {
               p(s"$high high vulnerabilities"),
               p(s"$medium medium vulnerabilities"),
               p(s"$low low vulnerabilities")
+            ),
+            div(
+              p("See the TDR developer manual for guidance on fixing these vulnerabilities: " +
+                "https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/alerts/ecr-scans.md")
             )
           )
         ).toString()

--- a/src/test/scala/uk/gov/nationalarchives/scannotifications/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/scannotifications/LambdaSpec.scala
@@ -13,12 +13,11 @@ class LambdaSpec extends LambdaSpecUtils {
       emailBody match {
         case Some(body) =>
           "the process method" should s"send an email message for event $input" in {
-            val expectedBody = Base64.getEncoder.encodeToString(body.getBytes(StandardCharsets.UTF_8))
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSesEndpoint.verify(1,
               postRequestedFor(urlEqualTo("/"))
-                .withRequestBody(binaryEqualTo(expectedBody))
+                .withRequestBody(equalTo(body))
             )
           }
         case None =>

--- a/src/test/scala/uk/gov/nationalarchives/scannotifications/LambdaSpecUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/scannotifications/LambdaSpecUtils.scala
@@ -82,7 +82,12 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
       s"$critical+critical+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
       s"$high+high+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
       s"$medium+medium+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
-      s"$low+low+vulnerabilities%3C%2Fp%3E%3C%2Fdiv%3E%3C%2Fbody%3E%3C%2Fhtml%3E" +
+      s"$low+low+vulnerabilities%3C%2Fp%3E%3C%2Fdiv%3E" +
+      "%3Cdiv%3E%3Cp%3E" +
+      "See+the+TDR+developer+manual+for+guidance+on+fixing+these+vulnerabilities%3A+" +
+      "https%3A%2F%2Fgithub.com%2Fnationalarchives%2Ftdr-dev-documentation%2Fblob%2Fmaster%2Fmanual%2Falerts%2Fecr-scans.md" +
+      "%3C%2Fp%3E%3C%2Fdiv%3E" +
+      "%3C%2Fbody%3E%3C%2Fhtml%3E" +
       "&Message.Body.Html.Charset=UTF-8"
   }
 
@@ -119,6 +124,12 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
        |    "text" : {
        |      "type" : "mrkdwn",
        |      "text" : "$low low severity vulnerabilities"
+       |    }
+       |  }, {
+       |    "type" : "section",
+       |    "text" : {
+       |      "type" : "mrkdwn",
+       |      "text" : "See the TDR developer manual for guidance on fixing these vulnerabilities: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/alerts/ecr-scans.md"
        |    }
        |  } ]
        |}


### PR DESCRIPTION
This gives the dev team some guidance when fixing the alerts.